### PR TITLE
Pinmap - removal of common pinmap declarations

### DIFF
--- a/mbed-hal/pinmap.h
+++ b/mbed-hal/pinmap.h
@@ -1,5 +1,6 @@
 /* mbed Microcontroller Library
- * Copyright (c) 2006-2013 ARM Limited
+ * Copyright (c) 2006-2015 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,24 +18,14 @@
 #define MBED_PINMAP_H
 
 #include "PinNames.h"
+#include "pinmap_common.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-typedef struct {
-    PinName pin;
-    int peripheral;
-    int function;
-} PinMap;
-
 void pin_function(PinName pin, int function);
-void pin_mode    (PinName pin, PinMode mode);
-
-uint32_t pinmap_peripheral(PinName pin, const PinMap* map);
-uint32_t pinmap_merge     (uint32_t a, uint32_t b);
-void     pinmap_pinout    (PinName pin, const PinMap *map);
-uint32_t pinmap_find_peripheral(PinName pin, const PinMap* map);
+void pin_mode(PinName pin, PinMode mode);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
There's one more thing left to do, I'll create an issue for that in this repo - targets should include common header if they need it, currently all they include is pinmap.h, therefore I added  the line 20 at the moment (to be pedantic, pinmap should be renamed to pinmap_api.h)

@bogdanm @bremoran