### PR TITLE
Correct some rename warnings

### DIFF
--- a/mbed-hal/pinmap.h
+++ b/mbed-hal/pinmap.h
@@ -18,7 +18,7 @@
 #define MBED_PINMAP_H
 
 #include "PinNames.h"
-#include "pinmap_common.h"
+#include "mbed-drivers/pinmap_common.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Correct warnings caused by https://github.com/ARMmbed/mbed-drivers/pull/104