### PR TITLE
Add nuvoton target dependency

### DIFF
--- a/module.json
+++ b/module.json
@@ -35,6 +35,9 @@
     },
     "cordio": {
       "mbed-hal-cordio": "~0.0.5"
+    },
+    "nuvoton": {
+      "mbed-hal-nuvoton": "^1.0.0"
     }
   }
 }


### PR DESCRIPTION
This is Nuvoton PR for adding mbed-hal-nuvoton module into module.json .
```
    "cordio": {
      "mbed-hal-cordio": "~0.0.5"
    },
    "nuvoton": {
      "mbed-hal-nuvoton": "^1.0.0"
    }
```