### PR TITLE
NXP chip support & I2C build fix

### DIFF
--- a/mbed-hal/i2c_api.h
+++ b/mbed-hal/i2c_api.h
@@ -19,6 +19,10 @@
 #include "device.h"
 #include "buffer.h"
 
+#if DEVICE_I2C_ASYNCH
+#include "dma_api.h"
+#endif
+
 #if DEVICE_I2C
 
 /**

--- a/module.json
+++ b/module.json
@@ -39,7 +39,7 @@
     "nuvoton": {
       "mbed-hal-nuvoton": "^1.0.0"
     },
-	"nxp": {
+    "nxp": {
       "mbed-hal-nxp": "~0.1.0"
     }
   }

--- a/module.json
+++ b/module.json
@@ -38,6 +38,9 @@
     },
     "nuvoton": {
       "mbed-hal-nuvoton": "^1.0.0"
+    },
+	"nxp": {
+      "mbed-hal-nxp": "~0.1.0"
     }
   }
 }


### PR DESCRIPTION
 - Included support for NXP chips
 - Build errors observed when ASYNC flag is enabled (Issue already raised in Github - ARM Internal Ref: IOTSFW-1723)
